### PR TITLE
Update 090-material-finalize.json

### DIFF
--- a/json/material/090-material-finalize.json
+++ b/json/material/090-material-finalize.json
@@ -207,19 +207,6 @@
       "mode": "row-based"
     },
     "columnName": "authorized_label_add",
-    "expression": "grel:if(cells[\"recon-material\"].value.contains(\"paper\"),\"paper\",value)",
-    "onError": "keep-original",
-    "repeat": false,
-    "repeatCount": 10,
-    "description": "Text transform on cells in column authorized_label_add using expression grel:if(cells[\"recon-material\"].value.contains(\"paper\"),\"paper\",value)"
-  },
-  {
-    "op": "core/text-transform",
-    "engineConfig": {
-      "facets": [],
-      "mode": "row-based"
-    },
-    "columnName": "authorized_label_add",
     "expression": "grel:if(cells[\"recon-material\"].value.contains(\"bark\"),\"bark\",value)",
     "onError": "keep-original",
     "repeat": false,


### PR DESCRIPTION
Removed redundancy: lines 177-189 and 203-215 were identical, so the latter section was deleted. 
Description: "Text transform on cells in column authorized_label_add using expression grel:if(cells[\"recon-material\"].value.contains(\"paper\"),\"paper\",value)"