### PR TITLE
Update 090-material-finalize.json

### DIFF
--- a/json/material/090-material-finalize.json
+++ b/json/material/090-material-finalize.json
@@ -570,12 +570,12 @@
       "facets": [],
       "mode": "row-based"
     },
-    "columnName": "authorized_label_add",
+    "columnName": "structured_value_add",
     "expression": "grel:if(cells[\"authorized_label_add\"].value==\"papyrus\",\"http://vocab.getty.edu/aat/300014127\",value)",
     "onError": "keep-original",
     "repeat": false,
     "repeatCount": 10,
-    "description": "Text transform on cells in column authorized_label_add using expression grel:if(cells[\"authorized_label_add\"].value==\"papyrus\",\"http://vocab.getty.edu/aat/300014127\",value)"
+    "description": "Text transform on cells in column structured_value_add using expression grel:if(cells[\"authorized_label_add\"].value==\"papyrus\",\"http://vocab.getty.edu/aat/300014127\",value)"
   },
   {
     "op": "core/text-transform",


### PR DESCRIPTION
Original version of this recipe for the value ‘papyrus' put the structured value in the authorized label column and left the structured value column blank. Fixed!