### PR TITLE
Update 030-language-recon.json

### DIFF
--- a/instructions/json/language/030-language-recon.json
+++ b/instructions/json/language/030-language-recon.json
@@ -301,6 +301,19 @@
     "repeatCount": 10,
     "description": "Text transform on cells in column recon-language using expression grel:value.replace(\"some \",\"\")"
   },
+    {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "recon-language",
+    "expression": "grel:value.replace(\"and \",\"\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column recon-language using expression grel:value.replace(\"and \",\"\")"
+  },
   {
     "op": "core/recon",
     "engineConfig": {


### PR DESCRIPTION
Added recipe to account for an 'and' appearing in the recon column.